### PR TITLE
AD field from FORMAT not included in TSV output

### DIFF
--- a/vcfkit/vcf2tsv.py
+++ b/vcfkit/vcf2tsv.py
@@ -68,6 +68,8 @@ if __name__ == '__main__':
     else:
         info = [m.groupdict()["id"] for m in r_info.finditer(v.raw_header)]
         format = [m.groupdict()["id"] for m in r_format.finditer(v.raw_header)]
+        if "AD" not in format:
+            format.append("AD")
 
     # Construct Query String
     print_header = ""


### PR DESCRIPTION
Fixes the omission of the 'AD' (Allelic Depths) column in the TSV file generated from the VCF. Allelic depth values for the reference and alternate alleles are now correctly included, extracted from the 'AD' field in the VCF FORMAT column.